### PR TITLE
Set machine card background to purple

### DIFF
--- a/machines-grid/src/Code.js
+++ b/machines-grid/src/Code.js
@@ -11,7 +11,7 @@ const CONFIG = {
     danger:   '#EF4444',
     access:   '#00C6D7',
     text:     '#0f172a',
-    card:     '#ffffff',
+    card:     '#800080',
     cardEdge: '#e5e7eb'
   }
 };

--- a/machines-grid/src/Index.html
+++ b/machines-grid/src/Index.html
@@ -33,7 +33,7 @@
       grid-template-columns: repeat(auto-fill, minmax(260px,1fr));
     }
     .card{
-      display:flex; flex-direction:column; background:var(--card); border:1px solid var(--card-edge);
+      display:flex; flex-direction:column; background:#800080; border:1px solid var(--card-edge);
       border-radius:16px; overflow:hidden;
       box-shadow: 0 10px 14px rgba(0,0,0,.06);
     }


### PR DESCRIPTION
## Summary
- make machine cards purple by default
- sync CONFIG.BRAND.card with new purple color

## Testing
- `npm test` *(fails: could not read package.json)*
- `git push` *(fails: No configured push destination)*
- `clasp push` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08e04608883319e54587d6de6c1d2